### PR TITLE
Account for non image reference

### DIFF
--- a/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
+++ b/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
@@ -70,15 +70,16 @@ class GalleryViewHelper extends AbstractTagBasedViewHelper
         $result = '';
 
         foreach ($images as $image) {
+            if ($image instanceof Image) {
+                /** @var Image $image */
+                $this->templateVariableContainer->add('image', $image);
+                $this->templateVariableContainer->add('imageMeta', $this->buildImageMetaDataArray($image));
 
-            /** @var Image $image */
-            $this->templateVariableContainer->add('image', $image);
-            $this->templateVariableContainer->add('imageMeta', $this->buildImageMetaDataArray($image));
+                $result .= $this->renderChildren();
 
-            $result .= $this->renderChildren();
-
-            $this->templateVariableContainer->remove('image');
-            $this->templateVariableContainer->remove('imageMeta');
+                $this->templateVariableContainer->remove('image');
+                $this->templateVariableContainer->remove('imageMeta');
+            }
         }
 
         $this->templateVariableContainer->remove('themeSettings');


### PR DESCRIPTION
As the asset type allows for multiple media types to be added issues can arrise when assuming that the reference is an image, the users may accidentally select a pdf etc. when the auto-generated thumbnail is similar to the image they require.