### PR TITLE
BUGFIX: remove 2nd (nested) class 'lightbox-images'

### DIFF
--- a/Classes/DL/Gallery/DataSources/AssetCollectionDataSource.php
+++ b/Classes/DL/Gallery/DataSources/AssetCollectionDataSource.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DL\Gallery\DataSources;
+
+/***************************************************************
+ *  Copyright (C) 2015 Daniel Lienert
+ *
+ *  This script is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\Flow\Utility\TypeHandling;
+use TYPO3\Neos\Service\DataSource\AbstractDataSource;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\Flow\Annotations as Flow;
+
+class AssetCollectionDataSource extends AbstractDataSource
+{
+
+    /**
+     * @var string
+     */
+    static protected $identifier = 'dl-gallery-assetcollections';
+
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Media\Domain\Repository\AssetCollectionRepository
+     */
+    protected $assetCollectionRepository;
+
+
+    /**
+     * @param NodeInterface|null $node
+     * @param array $arguments
+     * @return \TYPO3\Flow\Persistence\QueryResultInterface
+     */
+    public function getData(NodeInterface $node = null, array $arguments)
+    {
+        $options = [];
+        // Empty value
+        $options[] = ['label' => '', 'value' => '~'];
+        $assetCollections = $this->assetCollectionRepository->findAll();
+        foreach ($assetCollections as $assetCollection) {
+            /** @var \TYPO3\Media\Domain\Model\AssetCollection $assetCollection */
+            $options[] = [
+                'label' => $assetCollection->getTitle(),
+                'value' => json_encode([
+                    '__identity' => $this->persistenceManager->getIdentifierByObject($assetCollection),
+                    '__type' => TypeHandling::getTypeForValue($assetCollection)
+                ])
+            ];
+        }
+       return $options;
+    }
+
+}

--- a/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
+++ b/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
@@ -86,19 +86,26 @@ class GalleryViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedVie
 
         $result = '';
 
+        $i = 0;
         foreach ($images as $image) {
             /** @var Image $image */
             $this->templateVariableContainer->add('image', $image);
             $this->templateVariableContainer->add('imageMeta', $this->buildImageMetaDataArray($image));
+            if ($i === 0) {
+                $this->templateVariableContainer->add('isFirst', true);
+            } elseif ($this->templateVariableContainer->exists('isFirst')) {
+                $this->templateVariableContainer->remove('isFirst');
+            }
 
             $result .= $this->renderChildren();
 
             $this->templateVariableContainer->remove('image');
             $this->templateVariableContainer->remove('imageMeta');
+
+            $i++;
         }
 
         $this->templateVariableContainer->remove('themeSettings');
-
         return $result;
     }
 

--- a/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
+++ b/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
@@ -43,6 +43,12 @@ class GalleryViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedVie
     protected $imageRepository;
 
     /**
+     * @var \TYPO3\Flow\I18n\Translator
+     * @Flow\Inject
+     */
+    protected $translator;
+
+    /**
      * @var array
      */
     protected $settings;
@@ -73,8 +79,9 @@ class GalleryViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedVie
             $this->getSelectedImages($galleryNode)
         );
 
+
         if (count($images) === 0) {
-            return 'No images have been selected or no images have been assigned to the selected tag or asset collection.';
+            return $this->translator->translateById('gallery.noImagesSelected', [], null, null, 'Main', 'DL.Gallery');
         }
 
         $result = '';

--- a/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
+++ b/Classes/DL/Gallery/ViewHelpers/GalleryViewHelper.php
@@ -22,6 +22,7 @@ namespace DL\Gallery\ViewHelpers;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\QueryInterface;
+use TYPO3\Media\Domain\Model\AssetCollection;
 use TYPO3\Media\Domain\Model\Image;
 use TYPO3\Media\Domain\Model\Tag;
 use TYPO3\TYPO3CR\Domain\Model\Node;
@@ -68,11 +69,12 @@ class GalleryViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedVie
 
         $images = array_merge(
             $this->selectImagesByTag($galleryNode), 
+            $this->selectImagesByAssetCollection($galleryNode),
             $this->getSelectedImages($galleryNode)
         );
 
         if (count($images) === 0) {
-            return 'No images are assigned to the selected tag. Please go to the media management and assign images to this tag.';
+            return 'No images have been selected or no images have been assigned to the selected tag or asset collection.';
         }
 
         $result = '';
@@ -132,6 +134,30 @@ class GalleryViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedVie
         ]);
 
         $images = $this->imageRepository->findByTag($tag)->toArray();
+
+        return $images;
+    }
+
+    /**
+     * @param Node $galleryNode
+     * @return array
+     */
+    protected function selectImagesByAssetCollection(Node $galleryNode)
+    {
+        $assetCollection = $galleryNode->getProperty('assetCollection');
+
+        if(!($assetCollection instanceof AssetCollection)) {
+            return [];
+        }
+
+        $sortingField = $galleryNode->getProperty('sortingField') ?: 'resource.filename';
+        $sortingDirection = $galleryNode->getProperty('sortingDirection') === QueryInterface::ORDER_DESCENDING ? QueryInterface::ORDER_DESCENDING : QueryInterface::ORDER_ASCENDING;
+
+        $this->imageRepository->setDefaultOrderings([
+            $sortingField => $sortingDirection
+        ]);
+
+        $images = $this->imageRepository->findByAssetCollection($assetCollection)->toArray();
 
         return $images;
     }

--- a/Configuration/NodeTypes.Gallery.yaml
+++ b/Configuration/NodeTypes.Gallery.yaml
@@ -2,86 +2,85 @@
   superTypes:
     'TYPO3.Neos:Content': true
   ui:
-    label: Gallery
+    label: i18n
     icon: icon-picture
     position: 300
     inspector:
       groups:
         sourceBySelectedAssets:
-          label: Select Images
+          label: i18n
         sourceByTags:
-          label: Source by Tags
+          label: i18n
         presentation:
-          label: Presentation
+          label: i18n
   properties:
-
     assets:
       type: array<TYPO3\Media\Domain\Model\Asset>
       ui:
         inspector:
           group: sourceBySelectedAssets
-        label: Images
+        label: i18n
         reloadIfChanged: TRUE
 
-    tag:
-      type: string
-      ui:
-        label: Tags
-        inspector:
-          group: sourceByTags
-          editor: Content/Inspector/Editors/SelectBoxEditor
-          editorOptions:
-            dataSourceIdentifier: dl-gallery-tags
-        reloadIfChanged: true
     assetCollection:
       type: 'TYPO3\Media\Domain\Model\AssetCollection'
       ui:
-        label: Asset collections
+        label: i18n
         inspector:
           group: sourceByTags
-          editor: Content/Inspector/Editors/SelectBoxEditor
+          editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             dataSourceIdentifier: dl-gallery-assetcollections
+        reloadIfChanged: true
+    tag:
+      type: string
+      ui:
+        label: i18n
+        inspector:
+          group: sourceByTags
+          editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
+          editorOptions:
+            dataSourceIdentifier: dl-gallery-tags
         reloadIfChanged: true
     sortingField:
       type: string
       defaultValue: 'resource.filename'
       ui:
-        label: Sorting Field
+        label: i18n
         inspector:
           group: sourceByTags
-          editor: Content/Inspector/Editors/SelectBoxEditor
+          editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
              values:
               'resource.filename':
-                label: Name
+                label: i18n
               lastModified:
-                label: Last Modiefied
+                label: i18n
         reloadIfChanged: true
     sortingDirection:
       type: string
       defaultValue: ASC
       ui:
-        label: Sorting Direction
+        label: i18n
         inspector:
           group: sourceByTags
-          editor: Content/Inspector/Editors/SelectBoxEditor
+          editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
              values:
-              ASC:
-                label: Ascending
-              DESC:
-                label: Descending
+               ASC:
+                 label: i18n
+               DESC:
+                 label: i18n
         reloadIfChanged: true
 
     theme:
       type: string
       defaultValue: bootstrapLightbox
       ui:
-        label: Theme
+        label: i18n
         inspector:
           group: presentation
-          editor: Content/Inspector/Editors/SelectBoxEditor
+          editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             dataSourceIdentifier: dl-gallery-themes
         reloadIfChanged: true

--- a/Configuration/NodeTypes.Gallery.yaml
+++ b/Configuration/NodeTypes.Gallery.yaml
@@ -54,6 +54,8 @@
              values:
               'resource.filename':
                 label: i18n
+              title:
+                label: i18n
               lastModified:
                 label: i18n
         reloadIfChanged: true

--- a/Configuration/NodeTypes.Gallery.yaml
+++ b/Configuration/NodeTypes.Gallery.yaml
@@ -33,6 +33,16 @@
           editorOptions:
             dataSourceIdentifier: dl-gallery-tags
         reloadIfChanged: true
+    assetCollection:
+      type: 'TYPO3\Media\Domain\Model\AssetCollection'
+      ui:
+        label: Asset collections
+        inspector:
+          group: sourceByTags
+          editor: Content/Inspector/Editors/SelectBoxEditor
+          editorOptions:
+            dataSourceIdentifier: dl-gallery-assetcollections
+        reloadIfChanged: true
     sortingField:
       type: string
       defaultValue: 'resource.filename'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,14 @@ TYPO3:
       autoInclude:
         'DL.Gallery': TRUE
 
+    userInterface:
+      inspector:
+        dataTypes:
+          'TYPO3\Media\Domain\Model\AssetCollection':
+            typeConverter: 'TYPO3\Neos\TypeConverter\EntityToIdentityConverter'
+            editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
+            editorOptions:
+              dataSourceIdentifier: 'dl-gallery-assetcollections'
 
 DL:
   Gallery:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,8 +3,10 @@ TYPO3:
     typoScript:
       autoInclude:
         'DL.Gallery': TRUE
-
     userInterface:
+      translation:
+        autoInclude:
+          'DL.Gallery': ['NodeTypes/*']
       inspector:
         dataTypes:
           'TYPO3\Media\Domain\Model\AssetCollection':

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -57,3 +57,26 @@ DL:
             large:
               maximumWidth: 2000
               maximumHeight: 1200
+
+      bootstrapCarousel:
+        label: 'Bootstrap Carousel with Lightbox'
+        themeSettings:
+          galleryCSS: 'resource://DL.Gallery/Public/Styles/BootstrapLightbox.css'
+          galleryJS: 'resource://DL.Gallery/Public/JavaScript/BootstrapLightbox.min.js'
+
+          imageVariants:
+            thumb:
+              maximumWidth:
+              maximumHeight:
+              width: 900
+              height: 600
+              allowCropping: true
+              allowUpScaling:
+            large:
+              maximumWidth: 2000
+              maximumHeight: 1200
+              width:
+              height:
+              allowCropping:
+              allowUpScaling:
+

--- a/Resources/Private/Templates/Themes/BootstrapCarousel.html
+++ b/Resources/Private/Templates/Themes/BootstrapCarousel.html
@@ -1,0 +1,41 @@
+{namespace g = DL\Gallery\ViewHelpers}
+{namespace media=TYPO3\Media\ViewHelpers}
+
+
+<div {attributes -> f:format.raw()}>
+    <f:if condition="{imagesSelected}">
+        <f:then>
+            <div class="dl-gallery carousel-lightbox" itemscope itemtype="http://schema.org/ImageGallery">
+                <div id="carousel-{node.identifier}" class="carousel slide" data-ride="carousel" data-interval="false">
+                    <div class="carousel-inner" role="listbox">
+                        <g:gallery galleryNode="{node}">
+                            <figure itemprop="associatedMedia" itemtype="http://schema.org/ImageObject" class="carousel-item {f:if(condition: isFirst, then: 'active')} typo3-neos-nodetypes-image">
+                                <a href="{g:imageData(image:image, theme:'bootstrapCarousel', imageVariant:'large', key:'src')}" itemprop="contentUrl" data-size="{g:imageData(image:image theme:'bootstrapCarousel', imageVariant:'large', key:'width')}x{g:imageData(image:image theme:'bootstrapCarousel', imageVariant:'large', key:'height')}">
+                                    <g:image image="{image}" theme="bootstrapCarousel" imageVariant="thumb" additionalAttributes="{itemprop: 'thumbnail'}"/>
+                                </a>
+                                <figcaption itemprop="caption description">{g:imageData(image:image, theme:'bootstrapCarousel', imageVariant:'large', key:'caption')}</figcaption>
+                            </figure>
+                        </g:gallery>
+                     </div>
+                    <a class="left carousel-control" data-target="#carousel-{node.identifier}" role="button" data-slide="prev">
+                        <span class="icon-prev" aria-hidden="true"></span>
+                        <span class="sr-only">Previous</span>
+                    </a>
+                    <a class="right carousel-control" data-target="#carousel-{node.identifier}" role="button" data-slide="next">
+                        <span class="icon-next" aria-hidden="true"></span>
+                        <span class="sr-only">Next</span>
+                    </a>
+                </div>
+            </div>
+        </f:then>
+        <f:else>
+            <f:if condition="{node.context.workspace.name} != 'live'">
+                <div>Please select select some images or a tag in the inspector to display a gallery.</div>
+            </f:if>
+        </f:else>
+    </f:if>
+</div>
+
+<f:if condition="{requestFormat} == 'html'">
+    <f:render partial="PhotoSwipe" />
+</f:if>

--- a/Resources/Private/Templates/Themes/BootstrapLightbox.html
+++ b/Resources/Private/Templates/Themes/BootstrapLightbox.html
@@ -6,7 +6,7 @@
     <f:if condition="{imagesSelected}">
         <f:then>
 
-    <div class="dl-gallery lightbox-images" itemscope itemtype="http://schema.org/ImageGallery">
+    <div class="dl-gallery" itemscope itemtype="http://schema.org/ImageGallery">
         <div class="row dl-gallery">
             <g:gallery galleryNode="{node}">
                 <figure itemprop="associatedMedia" itemtype="http://schema.org/ImageObject" class="{themeSettings.columnClass} typo3-neos-nodetypes-image">

--- a/Resources/Private/Templates/Themes/Justified.html
+++ b/Resources/Private/Templates/Themes/Justified.html
@@ -16,7 +16,7 @@
         </f:then>
         <f:else>
             <f:if condition="{node.context.workspace.name} != 'live'">
-                <div>Please select select some images or a tag in the inspector to display a gallery.</div>
+                <div>Please select select some images, a tag or an asset collection in the inspector to display a gallery.</div>
             </f:if>
         </f:else>
     </f:if>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="DL.Gallery" source-language="en" datatype="plaintext">
+		<body>
+            <trans-unit id="gallery.noImagesSelected">
+                    <target>Es wurden weder Bilder noch eine Sammlung oder ein Tag ausgewählt oder die ausgewählte Sammlung oder der ausgewählte Tag enthält keine Bilder.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Gallery.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Gallery.xlf
@@ -29,6 +29,9 @@
 			<trans-unit id="properties.sortingField.selectBoxEditor.values.resource.filename" xml:space="preserve">
 				<target>Name</target>
 			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.title" xml:space="preserve">
+				<target>Titel</target>
+			</trans-unit>
 			<trans-unit id="properties.sortingField.selectBoxEditor.values.lastModified" xml:space="preserve">
 				<target>Zuletzt geändert</target>
 			</trans-unit>

--- a/Resources/Private/Translations/de/NodeTypes/Gallery.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Gallery.xlf
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="DL.Gallery" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="ui.label" xml:space="preserve">
+				<target>Bildergalerie</target>
+			</trans-unit>
+			<trans-unit id="groups.sourceBySelectedAssets" xml:space="preserve">
+				<target>Bilder auswählen</target>
+			</trans-unit>
+			<trans-unit id="groups.sourceByTags" xml:space="preserve">
+				<target>Bilder aus Sammlung/Tag</target>
+			</trans-unit>
+			<trans-unit id="groups.presentation" xml:space="preserve">
+				<target>Anzeige</target>
+			</trans-unit>
+			<trans-unit id="properties.assets" xml:space="preserve">
+				<target>Bilder</target>
+			</trans-unit>
+			<trans-unit id="properties.tag" xml:space="preserve">
+				<target>Tag</target>
+			</trans-unit>
+			<trans-unit id="properties.assetCollection" xml:space="preserve">
+				<target>Sammlung</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingField" xml:space="preserve">
+				<target>Sortieren nach</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.resource.filename" xml:space="preserve">
+				<target>Name</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.lastModified" xml:space="preserve">
+				<target>Zuletzt geändert</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection" xml:space="preserve">
+				<target>Sortierreihenfolge</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection.selectBoxEditor.values.ASC" xml:space="preserve">
+				<target>Aufsteigend</target>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection.selectBoxEditor.values.DESC" xml:space="preserve">
+				<target>Absteigend</target>
+			</trans-unit>
+			<trans-unit id="properties.theme" xml:space="preserve">
+				<target>Vorlage</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>
+
+

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="DL.Gallery" source-language="en" datatype="plaintext">
+		<body>
+            <trans-unit id="gallery.noImagesSelected">
+                    <source>No images have been selected or no images have been assigned to the selected tag or asset collection.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Gallery.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Gallery.xlf
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="DL.Gallery" source-language="en" datatype="plaintext">
+		<body>
+			<trans-unit id="ui.label" xml:space="preserve">
+				<source>Gallery</source>
+			</trans-unit>
+			<trans-unit id="groups.sourceBySelectedAssets" xml:space="preserve">
+				<source>Select Images</source>
+			</trans-unit>
+			<trans-unit id="groups.sourceByTags" xml:space="preserve">
+				<source>Images by Collection/Tag</source>
+			</trans-unit>
+			<trans-unit id="groups.presentation" xml:space="preserve">
+				<source>Presentation</source>
+			</trans-unit>
+			<trans-unit id="properties.assets" xml:space="preserve">
+				<source>Images</source>
+			</trans-unit>
+			<trans-unit id="properties.tag" xml:space="preserve">
+				<source>Tag</source>
+			</trans-unit>
+			<trans-unit id="properties.assetCollection" xml:space="preserve">
+				<source>Asset collection</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingField" xml:space="preserve">
+				<source>Sorting Field</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.resource.filename" xml:space="preserve">
+				<source>Name</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.lastModified" xml:space="preserve">
+				<source>Last Modified</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection" xml:space="preserve">
+				<source>Sorting Direction</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection.selectBoxEditor.values.ASC" xml:space="preserve">
+				<source>Ascending</source>
+			</trans-unit>
+			<trans-unit id="properties.sortingDirection.selectBoxEditor.values.DESC" xml:space="preserve">
+				<source>Descending</source>
+			</trans-unit>
+			<trans-unit id="properties.theme" xml:space="preserve">
+				<source>Theme</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>
+
+

--- a/Resources/Private/Translations/en/NodeTypes/Gallery.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Gallery.xlf
@@ -29,6 +29,9 @@
 			<trans-unit id="properties.sortingField.selectBoxEditor.values.resource.filename" xml:space="preserve">
 				<source>Name</source>
 			</trans-unit>
+			<trans-unit id="properties.sortingField.selectBoxEditor.values.title" xml:space="preserve">
+				<source>Title</source>
+			</trans-unit>
 			<trans-unit id="properties.sortingField.selectBoxEditor.values.lastModified" xml:space="preserve">
 				<source>Last Modified</source>
 			</trans-unit>

--- a/Resources/Private/TypoScript/NodeTypes/Gallery.ts2
+++ b/Resources/Private/TypoScript/NodeTypes/Gallery.ts2
@@ -7,5 +7,5 @@ prototype(DL.Gallery:Gallery) < prototype(TYPO3.Neos:Content) {
     }
 
     requestFormat = ${request.format}
-    imagesSelected = ${q(node).property('tag') || Type.isArray(q(node).property('assets'))}
+    imagesSelected = ${q(node).property('tag') || q(node).property('assetCollection') || Type.isArray(q(node).property('assets'))}
 }


### PR DESCRIPTION
class "lightbox-images" is used as selector for initializing PhotoSwipe and allready added to de enclosing div as attribute in Gallery.ts2. with the 2nd one the lightbox can only be opened once and is breaking other javascipts (on our pages)