### PR TITLE
BUGFIX: Alt tag no longer overridden by neos

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -78,6 +78,8 @@ class ImageViewHelper extends \Neos\Media\ViewHelpers\ImageViewHelper
             'alt' => $image->getCaption() ? $image->getCaption() : $image->getTitle()
         ]);
 
+        $this->arguments['alt'] = $this->tag->getAttribute('alt'); // so that parent::render doesn't override the alt
+
         return parent::render($image, $width, $maximumWidth, $height, $maximumHeight, $allowCropping, $allowUpScaling, $async, $preset);
     }
 


### PR DESCRIPTION
The ViewHelper now sets the argument "alt" so Neos won't delete the "alt"-tag.