### PR TITLE
BUGFIX: AssetCollection datasource value encoded twice

### DIFF
--- a/Classes/DataSources/AssetCollectionDataSource.php
+++ b/Classes/DataSources/AssetCollectionDataSource.php
@@ -54,10 +54,10 @@ class AssetCollectionDataSource extends AbstractDataSource
             /** @var AssetCollection $assetCollection */
             $options[] = [
                 'label' => $assetCollection->getTitle(),
-                'value' => json_encode([
+                'value' => [
                     '__identity' => $this->persistenceManager->getIdentifierByObject($assetCollection),
                     '__type' => TypeHandling::getTypeForValue($assetCollection)
-                ])
+                ]
             ];
         }
 


### PR DESCRIPTION
The DataSourceController using of JsonView class the value of option is json encoded twice.